### PR TITLE
Clear/ner Traceback

### DIFF
--- a/automain/__init__.py
+++ b/automain/__init__.py
@@ -1,9 +1,21 @@
 import inspect
 
 def automain(func):
-    locale = inspect.stack()[1][0].f_locals
-    module = locale.get("__name__", None)
-    if module == "__main__":
-        locale[func.__name__] = func
-        func()
-    return func
+    exc_info = None
+
+    try:
+        locale = inspect.stack()[1][0].f_locals
+        module = locale.get("__name__", None)
+        if module == "__main__":
+            locale[func.__name__] = func
+            func()
+        return func
+    except:
+        # skip the entry in the traceback that stems from within automain by raising the next entry
+        import sys
+        exc_info = sys.exc_info() # == exc_type, exc_value, exc_traceback
+        raise exc_info[0], exc_info[1], exc_info[2].tb_next
+    finally:
+        # clean up according to: https://docs.python.org/2/library/sys.html#sys.exc_info
+        del exc_info
+

--- a/example-traceback.py
+++ b/example-traceback.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from automain import *
+
+
+def test1():
+    test2()
+
+def test2():
+    ()[0]
+    print "You'll never see this printed ..."
+
+
+@automain
+def main():
+    print 'works!'
+    test1()
+


### PR DESCRIPTION
Hi Gerald,

we had briefly discussed renaming the internal `func` to either `main` or `main_func`, so that the traceback produced when `@automain` is used becomes clearer.

I think I might have found a much better solution:
Simply skip the entry about the internal function completely. This should be clearer and cleaner :)

I've tried to implement this idea. Hopefully, this didn't introduce any drawback or regression.

Best regards,
Sven
